### PR TITLE
Upgrade to Jitsi stable-11031 (4.2.0)Feature/upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-# Unreleased
+# 4.2.0
+
+* Upgrading to Jitsi version stable-11031
 
 # 4.1.1
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,8 +149,8 @@ This dual-load-balancer design allows SSL termination at ALB while supporting UD
 
 ### AMI Configuration
 
-The AMI is built via Packer (`packer/ami.json`) using `packer/ubuntu_2204_appinstall.sh`. It pre-installs:
-- Jitsi Meet (stable-9823)
+The AMI is built via Packer (`packer/ami.json`) using `packer/ubuntu_2404_appinstall.sh`. It pre-installs:
+- Jitsi Meet (stable-11031)
 - Docker and Docker Compose
 - CloudWatch agent
 - AWS Systems Manager agent

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ deploy: build
 	--require-approval never \
 	--parameters AlbCertificateArn=arn:aws:acm:us-east-1:992593896645:certificate/943928d7-bfce-469c-b1bf-11561024580e \
 	--parameters AlbIngressCidr=0.0.0.0/0 \
-	--parameters AsgAmiIdv411=ami-02691640f7dbc5aa1 \
+	--parameters AsgAmiIdv420=ami-0711e8ddaf70a1ce9 \
 	--parameters AsgReprovisionString=20251120.1 \
 	--parameters CustomDotEnvParameterArn=arn:aws:ssm:us-east-1:992593896645:parameter/oe-patterns-jitsi-dylan-custom-dot-env:4 \
 	--parameters CustomConfigJsParameterArn=arn:aws:ssm:us-east-1:992593896645:parameter/oe-patterns-jitsi-dylan-custom-config-js:1 \

--- a/cdk/jitsi/jitsi_stack.py
+++ b/cdk/jitsi/jitsi_stack.py
@@ -32,8 +32,8 @@ else:
     except:
         template_version = "CICD"
 
-AMI_ID="ami-02691640f7dbc5aa1" # ordinary-experts-patterns-jitsi-4.1.0-20260421-0615 (dev AMI for taskcat)
-NEXT_RELEASE_PREFIX="v411"
+AMI_ID="ami-0711e8ddaf70a1ce9" # ordinary-experts-patterns-jitsi-4.2.0-20260713-1007 (dev AMI for taskcat)
+NEXT_RELEASE_PREFIX="v420"
 
 class JitsiStack(Stack):
 

--- a/cdk/jitsi/user_data.sh
+++ b/cdk/jitsi/user_data.sh
@@ -27,12 +27,12 @@ EOF
   mv "$TEMP_FILE" "$FILE"
 }
 # Line numbers correspond to the `networks:` line of each service in
-# docker-jitsi-meet stable-10888's compose files (logging: is inserted
+# docker-jitsi-meet stable-11031's compose files (logging: is inserted
 # BEFORE that line so it lands at the end of the service's env block).
 # TODO: make pattern-based so this survives upstream shuffles.
-insert_logging_config "jvb" 513 "/root/jitsi-docker-jitsi-meet/docker-compose.yml"
-insert_logging_config "jicofo" 444 "/root/jitsi-docker-jitsi-meet/docker-compose.yml"
-insert_logging_config "prosody" 346 "/root/jitsi-docker-jitsi-meet/docker-compose.yml"
+insert_logging_config "jvb" 516 "/root/jitsi-docker-jitsi-meet/docker-compose.yml"
+insert_logging_config "jicofo" 447 "/root/jitsi-docker-jitsi-meet/docker-compose.yml"
+insert_logging_config "prosody" 349 "/root/jitsi-docker-jitsi-meet/docker-compose.yml"
 insert_logging_config "web" 195 "/root/jitsi-docker-jitsi-meet/docker-compose.yml"
 insert_logging_config "jibri" 64 "/root/jitsi-docker-jitsi-meet/jibri.yml"
 insert_logging_config "jigasi" 67 "/root/jitsi-docker-jitsi-meet/jigasi.yml"

--- a/packer/ubuntu_2404_appinstall.sh
+++ b/packer/ubuntu_2404_appinstall.sh
@@ -134,7 +134,7 @@ cd jitsi-docker-jitsi-meet
 docker compose -f docker-compose.yml -f jibri.yml -f etherpad.yml -f jigasi.yml pull
 cd /root
 
-pip install boto3
+pip install --break-system-packages boto3
 cat <<EOF > /root/check-secrets.py
 #!/usr/bin/env python3
 

--- a/packer/ubuntu_2404_appinstall.sh
+++ b/packer/ubuntu_2404_appinstall.sh
@@ -114,8 +114,8 @@ EOF
 # Jitsi configuration
 #
 
-# https://github.com/jitsi/docker-jitsi-meet/releases/tag/stable-10888 # 3/30/2026
-JITSI_VERSION=stable-10888
+# https://github.com/jitsi/docker-jitsi-meet/releases/tag/stable-11031 # 6/8/2026
+JITSI_VERSION=stable-11031
 
 cd /root
 echo $JITSI_VERSION >> /root/jitsi-image-version


### PR DESCRIPTION
## Summary

Upgrades the Jitsi pattern from stable-10888 to stable-11031, released as pattern version 4.2.0.

## Changes

- Bump `JITSI_VERSION` to `stable-11031` in `packer/ubuntu_2404_appinstall.sh`
- Fix `insert_logging_config` line numbers in `cdk/jitsi/user_data.sh` (jvb/jicofo/prosody shifted +3 lines due to new upstream Prosody `muc_resource_validate` config; web unchanged)
- Fix `pip install boto3` failing on Ubuntu 24.04 due to PEP 668 `externally-managed-environment` (added `--break-system-packages`) — this was affecting every AMI built from this script since the 4.1.1 Ubuntu 24.04 switch, caught during this upgrade's AMI validation
- Build new dev AMI: `ami-0711e8ddaf70a1ce9` (`ordinary-experts-patterns-jitsi-4.2.0-20260713-1007`)
- Bump versioned AMI CFN parameter suffix from `v411` to `v420` (`jitsi_stack.py` `NEXT_RELEASE_PREFIX`, `Makefile` deploy target)
- Add `CHANGELOG.md` 4.2.0 entry
- Fix stale `stable-9823` / `ubuntu_2204_appinstall.sh` references in `CLAUDE.md`'s AMI Configuration section

## Testing performed

- `make synth` / `make lint`: clean
- `AWS_PROFILE=oe-patterns-dev make deploy`: stack `oe-patterns-jitsi-iris` reached `CREATE_COMPLETE` (137/137 resources); ASG instance signaled success, confirming the boto3 fix works end-to-end
- Smoke tests (`test/integration/`): HTTPS reachable, TLS valid, `config.js` served, CloudFormation stack healthy (6/6 passed)
- Manual verification: site loads, meeting creation/join tested, whiteboard tested given the excalidraw version jump in this release
- `AWS_PROFILE=oe-patterns-dev make destroy`: clean teardown, independently verified via `describe-stacks`
- `AWS_PROFILE=oe-patterns-dev make test-main` (taskcat, us-east-1): `CREATE_COMPLETE` then `DELETE_COMPLETE`, no failures

## Known follow-ups (not addressed in this PR)

- devenv Dockerfile does not install `test/integration/requirements.txt`, so `make test-integration` has no pytest available out of the box
- `docker-compose.yml` does not pass `TEST_BASE_URL`/`TEST_STACK_NAME` through to the container, and `test/integration/config.yaml` defaults point at a different stack name (a prior developer's personal dev stack)
- `insert_logging_config`'s hardcoded line-number approach in `user_data.sh` is fragile across upstream releases (existing TODO in the file) — worth making pattern-based instead
- Multi-region `make test-all` has not been run for this release